### PR TITLE
Fixed 'git file blame' (<leader>gfb) shortcut

### DIFF
--- a/nvim/lua/moorby/plugins/blame.lua
+++ b/nvim/lua/moorby/plugins/blame.lua
@@ -15,6 +15,6 @@ return {
 
     -- Setup keymaps
     local keymap = vim.keymap
-    keymap.set("n", "<leader>gfb", ":ToggleBlame<CR>", {desc = "Toggle git blame (entire file)"})
+    keymap.set("n", "<leader>gfb", ":BlameToggle<CR>", {desc = "Toggle git blame (entire file)"})
   end
 }


### PR DESCRIPTION
The command was changed as indicated in the projects README in [this commit](https://github.com/FabijanZulj/blame.nvim/commit/1119ec70bc11da78e9ba1f2d9a3440e1a9dee636)